### PR TITLE
set max CWV bar to 99%

### DIFF
--- a/dashboard/src/lib/utils.js
+++ b/dashboard/src/lib/utils.js
@@ -15,11 +15,11 @@ export const formattedDate = dateString => {
 };
 
 export const calcCwvPercent = (val, good, medium) => {
-  const smallestGap = Math.min(good, medium-good);   
+  const smallestGap = Math.min(good, medium - good);   
   const total = medium + smallestGap;
 
   return {
-   percent: val/total * 100,
+   percent: Math.min(val/total * 100, 99),
    bounds: [ (good/total*100), ((medium-good)/total*100), (smallestGap/total*100) ]
   }
 }


### PR DESCRIPTION
When a CWV metric fell over 100% of the metered bar, the indicator would not be present. This PR sets it the CWV bar to 99% if it falls out of bounds.