### PR TITLE
Capture resource durations as first party data

### DIFF
--- a/api/src/events/performanceEntries/resourcePerformanceEntryEvent.js
+++ b/api/src/events/performanceEntries/resourcePerformanceEntryEvent.js
@@ -45,27 +45,24 @@ module.exports = class ResourcePerformanceEntryEvent {
   }
 
   _computedDurations(requestTiming) {
-    const hasDetailedTiming = requestTiming.responseStart > 0;
+    const hasDetailedTiming = parseFloat(requestTiming.responseStart) > 0;
     if (hasDetailedTiming) {
-      const firstTime = requestTiming.domainLookupStart || requestTiming.secureConnectionStart || requestTiming.requestStart || requestTiming.fetchStart;
-      const waiting_duration = firstTime - requestTiming.fetchStart;
-      const redirect_duration = requestTiming.redirectEnd - requestTiming.redirectStart;
-      // const service_worker_duration = requestTiming.responseEnd - (requestTiming.workerStart || requestTiming.responseEnd);
-      const dns_lookup_duration = requestTiming.domainLookupEnd - requestTiming.domainLookupStart;
-      const tcp_duration = requestTiming.secureConnectionStart - requestTiming.connectStart;
-      const ssl_duration = requestTiming.connectEnd - requestTiming.secureConnectionStart;
-      const request_duration = requestTiming.responseStart - requestTiming.requestStart;
-      const response_duration = requestTiming.responseEnd - requestTiming.responseStart;
-      return {
-        waiting_duration, 
-        redirect_duration, 
-        // service_worker_duration, 
-        dns_lookup_duration, 
-        tcp_duration, 
-        ssl_duration, 
-        request_duration, 
-        response_duration, 
-      };
+      const redirect_duration = parseFloat(requestTiming.redirectEnd) - parseFloat(requestTiming.redirectStart);
+      const dns_lookup_duration = parseFloat(requestTiming.domainLookupEnd) - parseFloat(requestTiming.domainLookupStart);
+      const tcp_duration = (parseFloat(requestTiming.secureConnectionStart || 0) || parseFloat(requestTiming.connectStart)) - parseFloat(requestTiming.connectStart);
+      const ssl_duration = parseFloat(requestTiming.connectEnd) - parseFloat(requestTiming.secureConnectionStart);
+      const request_duration = parseFloat(requestTiming.responseStart) - parseFloat(requestTiming.requestStart);
+      const response_duration = parseFloat(requestTiming.responseEnd) - parseFloat(requestTiming.responseStart);
+
+      const firstTime = dns_lookup_duration > 0 
+                          ? parseFloat(requestTiming.domainLookupStart || 0) 
+                          : tcp_duration > 0
+                            ? parseFloat(requestTiming.connectStart || 0) || parseFloat(requestTiming.secureConnectionStart || 0)
+                            : ssl_duration > 0 
+                              ? parseFloat(requestTiming.connectEnd || 0)
+                              : parseFloat(requestTiming.requestStart || 0) || parseFloat(requestTiming.fetchStart || 0);
+      const waiting_duration = firstTime - parseFloat(requestTiming.fetchStart);
+      return { waiting_duration, redirect_duration, dns_lookup_duration, tcp_duration, ssl_duration, request_duration, response_duration };
     } else {
       return {}
     }

--- a/api/tests/events/performanceEntries/resourcePerformanceEntry.test.js
+++ b/api/tests/events/performanceEntries/resourcePerformanceEntry.test.js
@@ -1,0 +1,215 @@
+const { prepareDb } = require('../../db');
+const DB = require('../../../src/db');
+const ResourcePerformanceEntryEvent = require('../../../src/events/performanceEntries/resourcePerformanceEntryEvent');
+
+const EVENT_DATA = {
+  uuid: 'resource-123',
+  pageViewUuid: 'page-view-identifier-xyz',
+  projectKey: 'site-identifier-123',
+  data: {
+    "name": encodeURIComponent("https://cdn.swishjam.com/latest/src.js"),
+    "entryType": "resource",
+    "startTime": 50.5,
+    "duration": 369.5,
+    "initiatorType": "script",
+    "nextHopProtocol": "h2",
+    "renderBlockingStatus": "non-blocking",
+    "workerStart": 0,
+    "redirectStart": 0,
+    "redirectEnd": 0,
+    "fetchStart": 50.5,
+    "domainLookupStart": 76.10000000009313,
+    "domainLookupEnd": 76.10000000009313,
+    "connectStart": 76.10000000009313,
+    "secureConnectionStart": 394.3000000002794,
+    "connectEnd": 406.20000000018626,
+    "requestStart": 406.3000000002794,
+    "responseStart": 419.40000000037253,
+    "responseEnd": 420,
+    "transferSize": 6340,
+    "encodedBodySize": 6040,
+    "decodedBodySize": 24540,
+    "responseStatus": 0,
+    "serverTiming": [
+      {
+        "name": "cdn-cache-hit",
+        "duration": 0,
+        "description": ""
+      },
+      {
+        "name": "cdn-pop",
+        "duration": 0,
+        "description": "SFO5-P2"
+      },
+      {
+        "name": "cdn-rid",
+        "duration": 0,
+        "description": "r1SHpbM-CZtK4bHiFJgGhrvU_BZUnNyprNWaZdLrad1Rx2Mdc_bZuw=="
+      },
+      {
+        "name": "cdn-hit-layer",
+        "duration": 0,
+        "description": "EDGE"
+      },
+      {
+        "name": "cdn-downstream-fbl",
+        "duration": 4,
+        "description": ""
+      }
+    ]
+  }
+}
+
+const NON_DETAILED_EVENT_DATA = {
+  uuid: 'resource-123',
+  pageViewUuid: 'page-view-identifier-xyz',
+  projectKey: 'site-identifier-123',
+  data: {
+    "name": encodeURIComponent("https://cdn.swishjam.com/latest/src.js"),
+    "entryType": "resource",
+    "startTime": 50.5,
+    "duration": 369.5,
+    "initiatorType": "script",
+    "nextHopProtocol": "h2",
+    "renderBlockingStatus": "non-blocking",
+    "workerStart": 0,
+    "redirectStart": 0,
+    "redirectEnd": 0,
+    "fetchStart": 50.5,
+    "domainLookupStart": 0,
+    "domainLookupEnd": 0,
+    "connectStart": 0,
+    "secureConnectionStart": 0,
+    "connectEnd": 0,
+    "requestStart": 0,
+    "responseStart": 0,
+    "responseEnd": 420,
+    "transferSize": 0,
+    "encodedBodySize": 0,
+    "decodedBodySize": 0,
+    "responseStatus": 0,
+    "serverTiming": [
+      {
+        "name": "cdn-cache-hit",
+        "duration": 0,
+        "description": ""
+      },
+      {
+        "name": "cdn-pop",
+        "duration": 0,
+        "description": "SFO5-P2"
+      },
+      {
+        "name": "cdn-rid",
+        "duration": 0,
+        "description": "r1SHpbM-CZtK4bHiFJgGhrvU_BZUnNyprNWaZdLrad1Rx2Mdc_bZuw=="
+      },
+      {
+        "name": "cdn-hit-layer",
+        "duration": 0,
+        "description": "EDGE"
+      },
+      {
+        "name": "cdn-downstream-fbl",
+        "duration": 4,
+        "description": ""
+      }
+    ]
+  }
+}
+
+describe('ResourcePerformanceEntry', () => {
+  beforeEach(async () => await prepareDb());
+
+  it('creates a resource_performance_entry with detailed timings', async () => {
+    const db = DB.connect();
+    await new ResourcePerformanceEntryEvent(EVENT_DATA, db).create();
+    const resources = await db.client`SELECT * FROM resource_performance_entries`;
+    expect(resources.length).toEqual(1);
+    expect(resources[0].uuid).toEqual(EVENT_DATA.uuid);
+    expect(resources[0].page_view_uuid).toEqual(EVENT_DATA.pageViewUuid);
+    expect(resources[0].project_key).toEqual(EVENT_DATA.projectKey);
+    expect(resources[0].name).toEqual(decodeURIComponent(EVENT_DATA.data.name));
+    expect(resources[0].entry_type).toEqual(EVENT_DATA.data.entryType);
+    expect(resources[0].start_time).toEqual(EVENT_DATA.data.startTime.toString());
+    expect(resources[0].duration).toEqual(EVENT_DATA.data.duration.toString());
+    expect(resources[0].initiator_type).toEqual(EVENT_DATA.data.initiatorType.toString());
+    expect(resources[0].next_hop_protocol).toEqual(EVENT_DATA.data.nextHopProtocol.toString());
+    expect(resources[0].render_blocking_status).toEqual(EVENT_DATA.data.renderBlockingStatus.toString());
+    expect(resources[0].worker_start).toEqual(EVENT_DATA.data.workerStart.toString());
+    expect(resources[0].redirect_start).toEqual(EVENT_DATA.data.redirectStart.toString());
+    expect(resources[0].redirect_end).toEqual(EVENT_DATA.data.redirectEnd.toString());
+    expect(resources[0].fetch_start).toEqual(EVENT_DATA.data.fetchStart.toString());
+    expect(resources[0].domain_lookup_start).toEqual(EVENT_DATA.data.domainLookupStart.toString());
+    expect(resources[0].domain_lookup_end).toEqual(EVENT_DATA.data.domainLookupEnd.toString());
+    expect(resources[0].connect_start).toEqual(EVENT_DATA.data.connectStart.toString());
+    expect(resources[0].secure_connection_start).toEqual(EVENT_DATA.data.secureConnectionStart.toString());
+    expect(resources[0].connect_end).toEqual(EVENT_DATA.data.connectEnd.toString());
+    expect(resources[0].request_start).toEqual(EVENT_DATA.data.requestStart.toString());
+    expect(resources[0].response_start).toEqual(EVENT_DATA.data.responseStart.toString());
+    expect(resources[0].response_end).toEqual(EVENT_DATA.data.responseEnd.toString());
+    expect(resources[0].transfer_size).toEqual(EVENT_DATA.data.transferSize.toString());
+    expect(resources[0].encoded_body_size).toEqual(EVENT_DATA.data.encodedBodySize.toString());
+    expect(resources[0].decoded_body_size).toEqual(EVENT_DATA.data.decodedBodySize.toString());
+
+    expect(resources[0].name_to_url_host).toEqual('cdn.swishjam.com');
+    expect(resources[0].name_to_url_path).toEqual('/latest/src.js');
+    expect(resources[0].name_to_url_query).toEqual('');
+    
+
+    const firstTime = EVENT_DATA.data.domainLookupStart || EVENT_DATA.data.secureConnectionStart || EVENT_DATA.data.requestStart || EVENT_DATA.data.fetchStart;
+    expect(resources[0].waiting_duration).toEqual((firstTime - EVENT_DATA.data.fetchStart).toString())
+    expect(resources[0].redirect_duration).toEqual((EVENT_DATA.data.redirectEnd - EVENT_DATA.data.redirectStart).toString())
+    // expect(resources[0].service_worker_duration).toEqual((EVENT_DATA.data.responseEnd - (EVENT_DATA.data.workerStart || EVENT_DATA.data.responseEnd)).toString())
+    expect(resources[0].dns_lookup_duration).toEqual((EVENT_DATA.data.domainLookupEnd - EVENT_DATA.data.domainLookupStart).toString())
+    expect(resources[0].tcp_duration).toEqual((EVENT_DATA.data.secureConnectionStart - EVENT_DATA.data.connectStart).toString())
+    expect(resources[0].ssl_duration).toEqual((EVENT_DATA.data.connectEnd - EVENT_DATA.data.secureConnectionStart).toString())
+    expect(resources[0].request_duration).toEqual((EVENT_DATA.data.responseStart - EVENT_DATA.data.requestStart).toString())
+    expect(resources[0].response_duration).toEqual((EVENT_DATA.data.responseEnd - EVENT_DATA.data.responseStart).toString())
+  });
+  
+  it('creates a resource_performance_entry without detailed timings', async () => {
+    const db = DB.connect();
+    await new ResourcePerformanceEntryEvent(NON_DETAILED_EVENT_DATA, db).create();
+    const resources = await db.client`SELECT * FROM resource_performance_entries`;
+    expect(resources.length).toEqual(1);
+    expect(resources[0].uuid).toEqual(NON_DETAILED_EVENT_DATA.uuid);
+    expect(resources[0].page_view_uuid).toEqual(NON_DETAILED_EVENT_DATA.pageViewUuid);
+    expect(resources[0].project_key).toEqual(NON_DETAILED_EVENT_DATA.projectKey);
+    expect(resources[0].name).toEqual(decodeURIComponent(NON_DETAILED_EVENT_DATA.data.name));
+    expect(resources[0].entry_type).toEqual(NON_DETAILED_EVENT_DATA.data.entryType);
+    expect(resources[0].start_time).toEqual(NON_DETAILED_EVENT_DATA.data.startTime.toString());
+    expect(resources[0].duration).toEqual(NON_DETAILED_EVENT_DATA.data.duration.toString());
+    expect(resources[0].initiator_type).toEqual(NON_DETAILED_EVENT_DATA.data.initiatorType.toString());
+    expect(resources[0].next_hop_protocol).toEqual(NON_DETAILED_EVENT_DATA.data.nextHopProtocol.toString());
+    expect(resources[0].render_blocking_status).toEqual(NON_DETAILED_EVENT_DATA.data.renderBlockingStatus.toString());
+    expect(resources[0].worker_start).toEqual(NON_DETAILED_EVENT_DATA.data.workerStart.toString());
+    expect(resources[0].redirect_start).toEqual(NON_DETAILED_EVENT_DATA.data.redirectStart.toString());
+    expect(resources[0].redirect_end).toEqual(NON_DETAILED_EVENT_DATA.data.redirectEnd.toString());
+    expect(resources[0].fetch_start).toEqual(NON_DETAILED_EVENT_DATA.data.fetchStart.toString());
+    expect(resources[0].domain_lookup_start).toEqual(NON_DETAILED_EVENT_DATA.data.domainLookupStart.toString());
+    expect(resources[0].domain_lookup_end).toEqual(NON_DETAILED_EVENT_DATA.data.domainLookupEnd.toString());
+    expect(resources[0].connect_start).toEqual(NON_DETAILED_EVENT_DATA.data.connectStart.toString());
+    expect(resources[0].secure_connection_start).toEqual(NON_DETAILED_EVENT_DATA.data.secureConnectionStart.toString());
+    expect(resources[0].connect_end).toEqual(NON_DETAILED_EVENT_DATA.data.connectEnd.toString());
+    expect(resources[0].request_start).toEqual(NON_DETAILED_EVENT_DATA.data.requestStart.toString());
+    expect(resources[0].response_start).toEqual(NON_DETAILED_EVENT_DATA.data.responseStart.toString());
+    expect(resources[0].response_end).toEqual(NON_DETAILED_EVENT_DATA.data.responseEnd.toString());
+    expect(resources[0].transfer_size).toEqual(NON_DETAILED_EVENT_DATA.data.transferSize.toString());
+    expect(resources[0].encoded_body_size).toEqual(NON_DETAILED_EVENT_DATA.data.encodedBodySize.toString());
+    expect(resources[0].decoded_body_size).toEqual(NON_DETAILED_EVENT_DATA.data.decodedBodySize.toString());
+
+    expect(resources[0].name_to_url_host).toEqual('cdn.swishjam.com');
+    expect(resources[0].name_to_url_path).toEqual('/latest/src.js');
+    expect(resources[0].name_to_url_query).toEqual('');
+
+    expect(resources[0].waiting_duration).toEqual(null)
+    expect(resources[0].redirect_duration).toEqual(null)
+    // expect(resources[0].service_worker_duration).toEqual(null)
+    expect(resources[0].dns_lookup_duration).toEqual(null)
+    expect(resources[0].tcp_duration).toEqual(null)
+    expect(resources[0].ssl_duration).toEqual(null)
+    expect(resources[0].request_duration).toEqual(null)
+    expect(resources[0].response_duration).toEqual(null)
+  });
+});

--- a/dashboard/src/lib/utils.js
+++ b/dashboard/src/lib/utils.js
@@ -1,10 +1,3 @@
-export const sleep = (ms) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-
-export const fetcher = (url) => fetch(url).then((res) => res.json());
-
 const msToSeconds = (ms) => (ms / 1000).toFixed(2);
 
 const metricFormatter = (value = 0, metricUnits) => {

--- a/database/backfills/1680323399457-resource-durations.js
+++ b/database/backfills/1680323399457-resource-durations.js
@@ -14,28 +14,37 @@ module.exports.run = async () => {
       resource_performance_entries 
     WHERE 
       request_duration IS NULL AND 
-      CAST(response_start AS int) > 0`;
+      CAST(response_start AS int) > 0 AND
+      created_at > '2023-03-20 00:00:00.000000+00'
+    ORDER BY
+      created_at DESC
+  `;
   console.log(`Found ${resources.length} resources to update`);
   let i = 0;
   for (const resource of resources) {
     try {
       const { uuid } = resource;
-      const firstTime = parseFloat(resource.domain_lookup_start || resource.secure_connection_start || resource.request_start || resource.fetch_start);
-      const waiting_duration = firstTime - parseFloat(resource.fetch_start);
       const redirect_duration = parseFloat(resource.redirect_end) - parseFloat(resource.redirect_start);
-      const service_worker_duration = parseFloat(resource.response_end) - parseFloat(resource.worker_start || resource.response_end);
       const dns_lookup_duration = parseFloat(resource.domain_lookup_end) - parseFloat(resource.domain_lookup_start);
-      const tcp_duration = parseFloat(resource.secure_connection_start) - parseFloat(resource.connect_start);
-      const ssl_duration = parseFloat(resource.connect_end) - parseFloat(resource.secure_connection_start);
+      const tcp_duration = (parseFloat(resource.secure_connection_start) || parseFloat(resource.connect_start)) - parseFloat(resource.connect_start);
+      const ssl_duration = parseFloat(resource.request_start) - parseFloat(resource.secure_connection_start);
       const request_duration = parseFloat(resource.response_start) - parseFloat(resource.request_start);
       const response_duration = parseFloat(resource.response_end) - parseFloat(resource.response_start);
+      
+      const firstTime = dns_lookup_duration > 0
+                        ? parseFloat(resource.domain_lookup_start || 0)
+                        : tcp_duration > 0
+                          ? parseFloat(resource.connect_start || 0) || parseFloat(resource.secure_connection_start || 0)
+                          : ssl_duration > 0
+                            ? parseFloat(resource.connect_end || 0)
+                            : parseFloat(resource.request_start || 0) || parseFloat(resource.fetch_start || 0);
+      const waiting_duration = firstTime - parseFloat(resource.fetch_start);
       await client`
         UPDATE 
           resource_performance_entries 
         SET 
           waiting_duration = ${waiting_duration}, 
           redirect_duration = ${redirect_duration}, 
-          service_worker_duration = ${service_worker_duration},
           dns_lookup_duration = ${dns_lookup_duration},
           tcp_duration = ${tcp_duration},
           ssl_duration = ${ssl_duration},
@@ -45,8 +54,9 @@ module.exports.run = async () => {
           uuid = ${uuid}
       `;
       i += 1;
-      console.log(`waiting_duration = ${waiting_duration}, redirect_duration = ${redirect_duration}, service_worker_duration = ${service_worker_duration}, dns_lookup_duration = ${dns_lookup_duration}, tcp_duration = ${tcp_duration}, ssl_duration = ${ssl_duration}, request_duration = ${request_duration}, response_duration = ${response_duration}`)
-      console.log(`Updated ${resource.name} (${i}/${resources.length})\n`);
+      // console.log(`waiting_duration = ${waiting_duration}, redirect_duration = ${redirect_duration}, dns_lookup_duration = ${dns_lookup_duration}, tcp_duration = ${tcp_duration}, ssl_duration = ${ssl_duration}, request_duration = ${request_duration}, response_duration = ${response_duration}`)
+      console.log(`Updated ${resource.name}`);
+      console.log(`${(i/resources.length) * 100}% (${i}/${resources.length})\n`);
     } catch (err) {
       console.error(`Failed to update ${resource.name}`, err);
     }

--- a/database/backfills/1680323399457-resource-durations.js
+++ b/database/backfills/1680323399457-resource-durations.js
@@ -1,0 +1,56 @@
+const postgres = require('postgres');
+require('dotenv').config();
+const credentials = require(`${__dirname}/../credentials`)[process.env.NODE_ENV];
+
+console.log(`Running data migration on ${process.env.NODE_ENV} environment...`);
+const client = postgres({ ...credentials });
+
+module.exports.run = async () => {
+  console.log('running...')
+  const resources = await client`
+    SELECT 
+      * 
+    FROM 
+      resource_performance_entries 
+    WHERE 
+      request_duration IS NULL AND 
+      CAST(response_start AS int) > 0`;
+  console.log(`Found ${resources.length} resources to update`);
+  let i = 0;
+  for (const resource of resources) {
+    try {
+      const { uuid } = resource;
+      const firstTime = parseFloat(resource.domain_lookup_start || resource.secure_connection_start || resource.request_start || resource.fetch_start);
+      const waiting_duration = firstTime - parseFloat(resource.fetch_start);
+      const redirect_duration = parseFloat(resource.redirect_end) - parseFloat(resource.redirect_start);
+      const service_worker_duration = parseFloat(resource.response_end) - parseFloat(resource.worker_start || resource.response_end);
+      const dns_lookup_duration = parseFloat(resource.domain_lookup_end) - parseFloat(resource.domain_lookup_start);
+      const tcp_duration = parseFloat(resource.secure_connection_start) - parseFloat(resource.connect_start);
+      const ssl_duration = parseFloat(resource.connect_end) - parseFloat(resource.secure_connection_start);
+      const request_duration = parseFloat(resource.response_start) - parseFloat(resource.request_start);
+      const response_duration = parseFloat(resource.response_end) - parseFloat(resource.response_start);
+      await client`
+        UPDATE 
+          resource_performance_entries 
+        SET 
+          waiting_duration = ${waiting_duration}, 
+          redirect_duration = ${redirect_duration}, 
+          service_worker_duration = ${service_worker_duration},
+          dns_lookup_duration = ${dns_lookup_duration},
+          tcp_duration = ${tcp_duration},
+          ssl_duration = ${ssl_duration},
+          request_duration = ${request_duration},
+          response_duration = ${response_duration}
+        WHERE 
+          uuid = ${uuid}
+      `;
+      i += 1;
+      console.log(`waiting_duration = ${waiting_duration}, redirect_duration = ${redirect_duration}, service_worker_duration = ${service_worker_duration}, dns_lookup_duration = ${dns_lookup_duration}, tcp_duration = ${tcp_duration}, ssl_duration = ${ssl_duration}, request_duration = ${request_duration}, response_duration = ${response_duration}`)
+      console.log(`Updated ${resource.name} (${i}/${resources.length})\n`);
+    } catch (err) {
+      console.error(`Failed to update ${resource.name}`, err);
+    }
+  };
+  console.log('done')
+  process.exit(0);
+}

--- a/database/migrations/20230331234208-addResourceDurations.js
+++ b/database/migrations/20230331234208-addResourceDurations.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('resource_performance_entries', 'waiting_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'redirect_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'service_worker_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'dns_lookup_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'tcp_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'ssl_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'request_duration', { type: Sequelize.DECIMAL });
+    await queryInterface.addColumn('resource_performance_entries', 'response_duration', { type: Sequelize.DECIMAL }); 
+
+    await queryInterface.addColumn('resource_performance_entries', 'next_hop_protocol', { type: Sequelize.STRING }); 
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('resource_performance_entries', 'waiting_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'redirect_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'service_worker_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'dns_lookup_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'tcp_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'ssl_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'request_duration');
+    await queryInterface.removeColumn('resource_performance_entries', 'response_duration'); 
+
+    await queryInterface.removeColumn('resource_performance_entries', 'next_hop_protocol');
+  }
+};

--- a/database/package.json
+++ b/database/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "g": "npx sequelize-cli migration:generate",
     "db:m": "npx sequelize-cli db:migrate",
-    "data:m": "node -e 'require(\"./backfills/1678731674878-backfill-resource-performance-entries-name-to-urls.js\").run()'"
+    "data:m": "node -e 'require(\"./backfills/1680323399457-resource-durations.js\").run()'"
   }
 }
-


### PR DESCRIPTION
Previously we were only capturing the `resource_performance_entries` various lifecycle timestamps, and calculating the durations on the fly. This led to discrepancies on the calculation, and more difficult to aggregate resources performance at p75 levels.