### PR TITLE
Improved CWV dashboard charts

### DIFF
--- a/dashboard/src/app/cwv/[accronym]/page.js
+++ b/dashboard/src/app/cwv/[accronym]/page.js
@@ -64,7 +64,7 @@ export default function CWV({ params }) {
   const getAndSetGoodNeedsImprovementChartData = ({ urlHost, urlPath, deviceTypes, setterMethod }) => {
     const params = { urlHost, urlPath, metrics: JSON.stringify([accronym]), deviceTypes: JSON.stringify(deviceTypes) };
     if (urlPath === 'All Paths') delete params.urlPath;
-    WebVitalsApi.getGoodNeedsImprovementChartData(params).then(data => {
+    WebVitalsApi.getGoodNeedsImprovementChartData(params).then(({ data }) => {
       const formatted = data[accronym].map(data => {
         return ({
           date: data.date,

--- a/dashboard/src/components/Charts/BarChart.js
+++ b/dashboard/src/components/Charts/BarChart.js
@@ -1,0 +1,84 @@
+import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, Legend, Bar } from "recharts"
+
+const defaultTooltipDisplay = ({ payload, label, colors, hideTooltipNames, yAxisDataFormatter, yAxisNameFormatter, tooltipDescriptionFormatter }) => (
+  <div className="custom-tooltip bg-white w-fit p-4 relative border border-gray-300 rounded-lg min-w-72">
+    <div className='w-full mb-2'>
+      <span className="text-xs text-gray-400">{label}</span>
+    </div>
+    {payload.map(({ name, value }, i) => (
+      !hideTooltipNames.includes(name) && (
+        <div className='flex justify-between items-center' key={i}>
+          <div className='text-xs text-gray-700 inline-flex items-center font-bold'>
+            <div className='inline-block w-2 h-2 mr-2 rounded-full' style={{ backgroundColor: colors[i] }} />
+            {yAxisDataFormatter(value)}
+          </div>
+          <div className={`text-xs text-gray-700 flex items-center justify-end ml-4`}>
+            {yAxisNameFormatter(name)}
+          </div>
+        </div>
+      )
+    ))}
+    <div className='text-center text-gray-400 mt-2 text-center' style={{ fontSize: '0.6rem' }}>
+      {tooltipDescriptionFormatter(label)}
+    </div>
+  </div>
+)
+
+export default function SwishjamBarChart({ 
+  data, 
+  xAxisKey,
+  keys,
+  colors,
+  stacked = false,
+  xAxisDataFormatter = val => val,
+  yAxisDataFormatter = val => val,
+  yAxisNameFormatter = val => val,
+  tooltipDescriptionFormatter = val => val,
+  tooltipDisplay = defaultTooltipDisplay,
+  hideTooltipNames = [],
+  yAxisTickFormatter,
+  height = 'h-72', 
+  yAxisMin,
+  yAxisMax,
+  yAxisIncrements,
+  includeYAxis = true,
+  includeLegend = true 
+}) {
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return tooltipDisplay({ payload, label, colors, hideTooltipNames, yAxisDataFormatter, yAxisNameFormatter, tooltipDescriptionFormatter }) || defaultTooltipDisplay({ payload, label, colors, hideTooltipNames, yAxisDataFormatter, yAxisNameFormatter, tooltipDescriptionFormatter });
+    }
+  }
+
+  const formattedData = data.map(datum => ({
+    ...datum,
+    [xAxisKey]: xAxisDataFormatter(datum[xAxisKey])
+  }));
+
+  const explicitYAxis = typeof yAxisMin === 'number' && typeof yAxisMax === 'number' 
+                          ? [...Array.from({ length: (yAxisMax - yAxisMin) / (yAxisIncrements || 20) }).map((_, i) => yAxisMin + (i * (yAxisIncrements || 20))), yAxisMax]
+                          : undefined;
+
+  return (
+    <div className={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={formattedData} margin={{ left: 0, top: 0, right: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey={xAxisKey} tick={{ fontSize: '10px', color: 'darkgrey' }} />
+          {typeof yAxisMin === 'number' && typeof yAxisMax === 'number'
+            ? <YAxis domain={[yAxisMin, yAxisMax]} hide={!includeYAxis} ticks={explicitYAxis} width={35} tick={{ fontSize: '10px', color: 'darkgrey' }} tickFormatter={yAxisTickFormatter || yAxisDataFormatter} />
+            : <YAxis hide={!includeYAxis} tick={{ fontSize: '10px', color: 'darkgrey' }} tickFormatter={yAxisTickFormatter || yAxisDataFormatter} />}
+          <Tooltip content={<CustomTooltip />} wrapperClassName='border border-gray-300' />
+          {includeLegend && <Legend />}
+          {keys.map((key, i) => {
+            if (stacked) {
+              return <Bar dataKey={key} fill={colors[i]} stackId='stack' key={i} />;
+            } else {
+              return <Bar dataKey={key} fill={colors[i]} key={i} />;
+            }
+          })}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/dashboard/src/components/WebVitals/CWVDashboardView.js
+++ b/dashboard/src/components/WebVitals/CWVDashboardView.js
@@ -29,8 +29,8 @@ export default function CwvDashboardView() {
     setNumPageViews();
   }
 
-  const getAndSetExperienceScoreTimeseriesData = async ({ urlHost, urlPath }) => {
-    const params = { urlHost, urlPath, metrics: JSON.stringify(['LCP', 'INP', 'CLS', 'FCP', 'FID', 'TTFB']) };
+  const getAndSetExperienceScoreTimeseriesData = async ({ urlHost, urlPath, groupBy = 'day' }) => {
+    const params = { urlHost, urlPath, groupBy, metrics: JSON.stringify(['LCP', 'INP', 'CLS', 'FCP', 'FID', 'TTFB']) };
     if (urlPath === 'All Paths' || !urlPath) delete params.urlPath;
     return WebVitalsApi.getTimeseriesData(params).then(data => {
       let dataWithExperienceScores = {};
@@ -48,9 +48,12 @@ export default function CwvDashboardView() {
   };
 
   const getAndSetBarChartsData = async ({ urlHost, urlPath }) => {
-    const params = { urlHost, urlPath, groupBy: 'day', metrics: JSON.stringify(['LCP', 'INP', 'CLS', 'FCP', 'FID', 'TTFB']) };
+    const params = { urlHost, urlPath, metrics: JSON.stringify(['LCP', 'INP', 'CLS', 'FCP', 'FID', 'TTFB']) };
     if (urlPath === 'All Paths' || !urlPath) delete params.urlPath;
-    return WebVitalsApi.getGoodNeedsImprovementChartData(params).then(setCwvBarChartData);
+    return WebVitalsApi.getGoodNeedsImprovementChartData(params).then(({ data, groupedBy }) => {
+      setCwvBarChartData(data);
+      getAndSetExperienceScoreTimeseriesData({ urlHost, urlPath, groupBy: groupedBy });
+    });
   }
 
   const getAndSetNumPageViews = async ({ urlHost, urlPath }) => {
@@ -65,7 +68,6 @@ export default function CwvDashboardView() {
       getAndSetNumPageViews({ urlHost, urlPath }),
       getAndSetBarChartsData({ urlHost, urlPath }), 
       getAndSetWebVitalPercentiles({ urlHost, urlPath }),
-      getAndSetExperienceScoreTimeseriesData({ urlHost, urlPath })
     ]);
   }
 

--- a/dashboard/src/components/WebVitals/MetricGauge.js
+++ b/dashboard/src/components/WebVitals/MetricGauge.js
@@ -11,12 +11,16 @@ export default function MetricGauge({ accronym, percentileValue }) {
   const percentageValue = Math.min(100, startingPercentage + ((percentileValue / totalSize) * 100));
   return (
     <div className='w-full'>
-      <CategoryBar
-        categoryPercentageValues={[(cwvBounds.good / totalSize) * 100, (cwvBounds.medium / totalSize) * 100, (sizeOfBad / totalSize) * 100]}
-        colors={["emerald", "yellow", "rose"]}
-        percentageValue={percentageValue}
-        showLabels={false}
-      />
+      {typeof percentileValue === 'number' 
+        ? (
+          <CategoryBar
+            categoryPercentageValues={[(cwvBounds.good / totalSize) * 100, (cwvBounds.medium / totalSize) * 100, (sizeOfBad / totalSize) * 100]}
+            colors={["emerald", "yellow", "rose"]}
+            percentageValue={percentageValue}
+            showLabels={false}
+          />
+        ) : <div className='w-full h-2 rounded bg-gray-400' />
+      }
       <div className='block'>
         <div className='inline-block text-xs text-gray-400 text-center' 
               style={{ width: `${((cwvBounds.good / totalSize) + ((cwvBounds.medium / totalSize) / 2)) * 100}%` }}>

--- a/dashboard/src/lib/api-client/web-vitals.js
+++ b/dashboard/src/lib/api-client/web-vitals.js
@@ -1,5 +1,6 @@
 import { API } from './base';
 import { formattedDate, monthByNumber } from '../utils';
+import { filledInTimeseries } from '@lib/utilities/timeseriesHelpers';
 
 export class WebVitalsApi extends API {
   static async average(data) {
@@ -30,30 +31,43 @@ export class WebVitalsApi extends API {
     const { results, groupedBy } = await API.get('/api/cwv/good-needs-improvement-bad', data);
     let formattedResults = {};
     Object.keys(results).forEach(metricKey => {
-      formattedResults[metricKey] = results[metricKey].map(datapoint => ({
+      formattedResults[metricKey] = filledInTimeseries({ timeseries: results[metricKey], groupedBy }).map(({ 
+        date, 
+        total_num_records = 0,
+        num_good_records = 0, 
+        num_needs_improvement_records = 0, 
+        num_bad_records = 0 
+      }) => ({
+        fullDate: date,
         date: groupedBy === 'day' 
-                ? formattedDate(datapoint.date, { includeTime: false }) 
+                ? formattedDate(date, { includeTime: false }) 
                 : groupedBy === 'week' 
-                  ? `Week of ${formattedDate(datapoint.date, { includeTime: false })}`
-                  : `Month of ${monthByNumber[parseInt(formattedDate(datapoint.date, { includeTime: false }).split('/')[0])]}`,
-        total: parseInt(datapoint.total_num_records),
-        numGood: parseInt(datapoint.num_good_records || 0),
-        percentGood: (parseInt(datapoint.num_good_records || 0) / parseInt(datapoint.total_num_records)) * 100,
-        numNeedsImprovement: parseInt(datapoint.num_needs_improvement_records || 0),
-        percentNeedsImprovement: (parseInt(datapoint.num_needs_improvement_records || 0) / parseInt(datapoint.total_num_records)) * 100,
-        numPoor: parseInt(datapoint.num_bad_records || 0),
-        percentPoor: (parseInt(datapoint.num_bad_records || 0) / parseInt(datapoint.total_num_records)) * 100,
+                  ? `Week of ${formattedDate(date, { includeTime: false })}`
+                  : `Month of ${monthByNumber[parseInt(formattedDate(date, { includeTime: false }).split('/')[0])]}`,
+        total: parseInt(total_num_records),
+        numGood: parseInt(num_good_records),
+        percentGood: (parseInt(num_good_records) / parseInt(total_num_records)) * 100,
+        numNeedsImprovement: parseInt(num_needs_improvement_records),
+        percentNeedsImprovement: (parseInt(num_needs_improvement_records) / parseInt(total_num_records)) * 100,
+        numPoor: parseInt(num_bad_records),
+        percentPoor: (parseInt(num_bad_records) / parseInt(total_num_records)) * 100,
+        noData: parseInt(total_num_records) === 0 ? 100 : 0,
       }));
     });
-    return formattedResults;
+    return { data: formattedResults, groupedBy };
   }
 
   static async getTimeseriesData(params) {
     const { results } = await API.get('/api/cwv/timeseries', params);
     let formattedResults = {};
+    const groupedBy = params.groupBy || 'day';
     Object.keys(results).forEach(metricKey => {
       formattedResults[metricKey] = results[metricKey].map(datapoint => ({
-        date: formattedDate(datapoint.date, { includeTime: false }),
+        date: groupedBy === 'day' 
+                ? formattedDate(datapoint.date, { includeTime: false })
+                : groupedBy === 'week'
+                  ? `Week of ${formattedDate(datapoint.date, { includeTime: false })}`
+                  : `Month of ${monthByNumber[parseInt(formattedDate(datapoint.date, { includeTime: false }).split('/')[0])]}`,
         value: parseFloat(datapoint.value),
       }));
     });

--- a/dashboard/src/lib/data/webVitals.js
+++ b/dashboard/src/lib/data/webVitals.js
@@ -217,7 +217,7 @@ export default class WebVitalsData {
     }
   }
 
-  static async getPercentileTimeseriesDataForMetric({ projectKey, metric, startTs, urlHost, urlPath, percentile = 0.75 }) {
+  static async getPercentileTimeseriesDataForMetric({ projectKey, metric, groupBy = 'day', startTs, urlHost, urlPath, percentile = 0.75 }) {
     if (!projectKey) throw new Error('Missing required parameter: `projectKey`');
     if (!urlHost) throw new Error('Missing required parameter: `urlHost`');
     if (!metric) throw new Error('Missing required parameter: `metric`');
@@ -225,7 +225,7 @@ export default class WebVitalsData {
       const query = `
         SELECT
           CAST(PERCENTILE_CONT(${percentile}) WITHIN GROUP (ORDER BY metric_value) AS float) AS value,
-          date_trunc('day', page_views.page_view_ts) AS date
+          date_trunc('${groupBy}', page_views.page_view_ts) AS date
         FROM
           performance_metrics
         LEFT JOIN

--- a/dashboard/src/lib/utilities/timeHelpers.js
+++ b/dashboard/src/lib/utilities/timeHelpers.js
@@ -1,0 +1,26 @@
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+const ONE_DAY_IN_MS = ONE_DAY_IN_SECONDS * 1000;
+
+const startOfDay = date => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+const dateToUTC = date => {
+  const d = new Date(date);
+  d.setUTCFullYear(d.getFullYear());
+  d.setUTCMonth(d.getMonth());
+  d.setUTCDate(d.getDate());
+  d.setUTCHours(d.getHours());
+  d.setUTCMinutes(d.getMinutes());
+  d.setUTCSeconds(d.getSeconds());
+  return d;
+}
+
+export { 
+  ONE_DAY_IN_SECONDS, 
+  ONE_DAY_IN_MS,
+  dateToUTC,
+  startOfDay, 
+}

--- a/dashboard/src/lib/utilities/timeseriesHelpers.js
+++ b/dashboard/src/lib/utilities/timeseriesHelpers.js
@@ -1,0 +1,13 @@
+import { ONE_DAY_IN_MS, startOfDay, dateToUTC } from "./timeHelpers";
+
+const filledInTimeseries = ({ timeseries, groupedBy, expectedNumDataPoints = 5 }) => {
+  if (timeseries.length >= expectedNumDataPoints) return timeseries;
+  const secondIncrements = groupedBy === 'day' ? ONE_DAY_IN_MS : groupedBy === 'week' ? ONE_DAY_IN_MS * 7 : ONE_DAY_IN_MS * 30;
+  const expectedTimes = Array.from({ length: expectedNumDataPoints }, (_, i) => dateToUTC(startOfDay(new Date() - secondIncrements * i)).toISOString());
+  expectedTimes.forEach(time => {
+    if (!timeseries.find(datapoint => datapoint.date === time)) timeseries.push({ date: time });
+  })
+  return timeseries;
+}
+
+export { filledInTimeseries }

--- a/dashboard/src/pages/api/cwv/good-needs-improvement-bad.js
+++ b/dashboard/src/pages/api/cwv/good-needs-improvement-bad.js
@@ -10,9 +10,9 @@ export default async (req, res) => {
     if (groupBy === 'intelligent') {
       const oldestRecord = await WebVitalsData.getOldestRecord({ projectKey, urlHost, urlPath, metric: 'LCP' });
       const oneDay = 1000 * 60 * 60 * 24;
-      if (oldestRecord && new Date(oldestRecord.date) <= new Date(oneDay * 30 * 5)) {
+      if (oldestRecord && new Date() - new Date(oldestRecord.date) >= new Date(oneDay * 30 * 5)) {
         groupBy = 'month';
-      } else if (oldestRecord && new Date(oldestRecord.date) <= new Date(oneDay * 7 * 5)) {
+      } else if (oldestRecord && new Date() - new Date(oldestRecord.date) >= new Date(oneDay * 7 * 5)) {
         groupBy = 'week';
       } else {
         groupBy = 'day';

--- a/dashboard/src/pages/api/cwv/timeseries.js
+++ b/dashboard/src/pages/api/cwv/timeseries.js
@@ -2,8 +2,14 @@ import { Validator } from '@/lib/queryValidator';
 import WebVitalsData from '@/lib/data/webVitals';
 
 export default async (req, res) => {
-  const defaultStartTs = Date.now() - 1000 * 60 * 60 * 24 * 7;
-  const { projectKey, metrics, urlHost, urlPath, percentile = 0.75, startTs = defaultStartTs } = req.query;
+  const oneDay = 1000 * 60 * 60 * 24;
+  const { projectKey, metrics, urlHost, urlPath, groupBy ='day', percentile = 0.75 } = req.query;
+  const startTs = req.query.startTs || groupBy === 'month'
+                    ? new Date(Date.now() - (oneDay * 30 * 5))
+                    : groupBy === 'week'
+                      ? new Date(Date.now() - (oneDay * 7 * 5))
+                      : new Date(Date.now() - (oneDay * 7));
+
   
   return await Validator.runQueryIfUserHasAccess({ req, res, projectKey }, async () => {
     try {
@@ -13,6 +19,7 @@ export default async (req, res) => {
           metric, 
           urlHost, 
           urlPath, 
+          groupBy,
           percentile: parseFloat(percentile), 
           startTs 
         })


### PR DESCRIPTION
Improves CWV charts by: 
1. Makes sure charts are always "filled in" (ie: if there's only enough data for one day, display gray bars for the other 4 days, rather than one fat bar currently). 
2. Intelligently groups by day, week, or month depending on how much data we have.
3. Moves from Tremor charts to custom Recharts for more verbose charts.